### PR TITLE
Remove continue-on-error from text lint workflow

### DIFF
--- a/.github/workflows/textlint.yml
+++ b/.github/workflows/textlint.yml
@@ -18,7 +18,6 @@ jobs:
         run: |
           echo "::set-output name=TEXTLINT_OUTPUT::$(./node_modules/.bin/textlint 'docs/**/*.md' -f json)"
         working-directory: ./textlint
-        continue-on-error: true
       - uses: yutailang0119/action-textlint@v1
         with:
           textlint_output: ${{ steps.run-textlint.outputs.TEXTLINT_OUTPUT }}


### PR DESCRIPTION
exit 1 when contains error.

```bash
$ ./node_modules/.bin/textlint 'docs/**/*.md' -f json
[{"messages":[{"type":"lint","ruleId":"ja-technical-writing/ja-unnatural-alphabet","message":"不自然なアルファベットがあります: r","index":25,"line":7,"column":3,"severity":2}],"filePath":"/sandbox-github-actions/textlint/docs/Foo.md"}]
$ echo $?
1
```

However, if wrap by `echo`, exit 0. (this change)

```bash
$ echo "::set-output name=TEXTLINT_OUTPUT::$(./node_modules/.bin/textlint 'docs/**/*.md' -f json)"
[{"messages":[{"type":"lint","ruleId":"ja-technical-writing/ja-unnatural-alphabet","message":"不自然なアルファベットがあります: r","index":25,"line":7,"column":3,"severity":2}],"filePath":"/sandbox-github-actions/textlint/docs/Foo.md"}]
$ echo $?
0
```

or return `true`
```bash
$ ./node_modules/.bin/textlint 'docs/**/*.md' -f json -o textlint-report.json || true
[{"messages":[{"type":"lint","ruleId":"ja-technical-writing/ja-unnatural-alphabet","message":"不自然なアルファベットがあります: r","index":25,"line":7,"column":3,"severity":2}],"filePath":"/sandbox-github-actions/textlint/docs/Foo.md"}]
$ echo $?
0
```

https://github.com/yutailang0119/sandbox-github-actions/blob/bfe3e968ebc41d736824037298ee2688c9e88f88/.github/workflows/textlint-with-file.yml#L18
