### PR TITLE
Fix using set-output in GitHub Actions

### DIFF
--- a/.github/workflows/textlint.yml
+++ b/.github/workflows/textlint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: run textlint
         id: run-textlint
         run: |
-          echo "::set-output name=TEXTLINT_OUTPUT::$(./node_modules/.bin/textlint 'docs/**/*.md' -f json)"
+          echo "TEXTLINT_OUTPUT=$(./node_modules/.bin/textlint 'docs/**/*.md' -f json)" >> $GITHUB_OUTPUT
         working-directory: ./textlint
       - uses: yutailang0119/action-textlint@v3.1.0
         with:


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/